### PR TITLE
master is depricated use control-plane 

### DIFF
--- a/Labs/02-Deployments-Imperative/README.md
+++ b/Labs/02-Deployments-Imperative/README.md
@@ -110,7 +110,7 @@ KubeDNS is running at https://192.168.49.2:8443/api/v1/namespaces/kube-system/se
 
 # Programmatically get the port and the IP
 CLUSTER_IP=$(kubectl get nodes \
-            --selector=node-role.kubernetes.io/master \
+            --selector=node-role.kubernetes.io/control-plane \
             -o jsonpath='{$.items[*].status.addresses[?(@.type=="InternalIP")].address}')
 
 NODE_PORT=$(kubectl get -o \


### PR DESCRIPTION
According to [labels-annotations-taints](https://kubernetes.io/docs/reference/labels-annotations-taints/)  **node-role.kubernetes.io/master** is deprecated.
We need to replace it into **node-role.kubernetes.io/control-plane**